### PR TITLE
nil block after execution

### DIFF
--- a/SAMRateLimit/SAMRateLimit.m
+++ b/SAMRateLimit/SAMRateLimit.m
@@ -34,6 +34,7 @@
 	// Execute block
 	if (executeBlock) {
 		block();
+    block = nil;
 	}
 
 	return executeBlock;


### PR DESCRIPTION
Maybe it is better to nil the block after execution to prevent retain cycles. 

Source: [Should I set block reference to nil AFTER execution?](http://stackoverflow.com/questions/14633466/should-i-set-block-reference-to-nil-after-execution)
