### PR TITLE
Refixed bug that was a bug and now has tests to show it

### DIFF
--- a/RateLimit/RateLimit.swift
+++ b/RateLimit/RateLimit.swift
@@ -60,8 +60,10 @@ public class RateLimit: NSObject {
 				should = true
 			}
 
-			// Record execution
-			dictionary[name] = NSDate()
+			// Record execution any time we actually execute
+            if (should) {
+                dictionary[name] = NSDate()
+            }
 		}
 		
         return should

--- a/Tests/RateLimitTests.swift
+++ b/Tests/RateLimitTests.swift
@@ -13,27 +13,36 @@ class RateLimitTests: XCTestCase {
 
     func testLimit() {
         let name = "testLimit"
+        let limit : NSTimeInterval = 5.0
 
         // It should get excuted first
         let expectation1 = expectationWithDescription("Execute 1")
-        var reported = RateLimit.execute(name: name, limit: 2) {
+        var reported = RateLimit.execute(name: name, limit: limit) {
             expectation1.fulfill()
         }
         XCTAssertTrue(reported)
         waitForExpectationsWithTimeout(0, handler: nil)
 
         // Not right away after
-        reported = RateLimit.execute(name: name, limit: 1) {
+        reported = RateLimit.execute(name: name, limit: limit) {
             XCTFail("This shouldn't have run.")
         }
         XCTAssertFalse(reported)
 
-		// Sleep for a second
-		sleep(1)
+		// Sleep for almost the whole time limit
+		sleep(UInt32(limit - 1.0))
 
-        // Now it should get executed
+        // Haven't waited long enough yet
+        reported = RateLimit.execute(name: name, limit: limit) {
+            XCTFail("This shouldn't have run.")
+        }
+        XCTAssertFalse(reported)
+
+		sleep(2)
+        
+        // Now it should get executed (after the full interval)
         let expectation2 = expectationWithDescription("Execute 2")
-        reported = RateLimit.execute(name: name, limit: 1) {
+        reported = RateLimit.execute(name: name, limit: limit) {
             expectation2.fulfill()
         }
         XCTAssertTrue(reported)


### PR DESCRIPTION
I was using the latest version of the library and it wasn't working as expected.  Calling RateLimit.execute() several times, and most notably, just before the time would normally expire, resets the execution time stored in the dictionary and, thus, the block is not executed.  I've updated the test so it passes with this change and fails with the previous code.