### PR TITLE
Expose execute function to Objective-C API's

### DIFF
--- a/RateLimit.xcodeproj/project.pbxproj
+++ b/RateLimit.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0.2;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -845,7 +845,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0.2;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -937,7 +937,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.samsoffes.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.2;
 			};
 			name = Debug;
 		};
@@ -950,7 +949,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.samsoffes.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0.2;
 			};
 			name = Release;
 		};
@@ -973,7 +971,6 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
@@ -997,7 +994,6 @@
 				PRODUCT_NAME = RateLimit;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
@@ -1016,7 +1012,6 @@
 				PRODUCT_NAME = RateLimitTests;
 				SDKROOT = appletvos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0.2;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
@@ -1033,7 +1028,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.samsoffes.ratelimit.tests;
 				PRODUCT_NAME = RateLimitTests;
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 3.0.2;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;

--- a/RateLimit/DebouncedLimiter.swift
+++ b/RateLimit/DebouncedLimiter.swift
@@ -31,7 +31,7 @@ public final class DebouncedLimiter: AsyncLimiter {
 
 	// MARK: - Limiter
 
-	public func execute() {
+	@objc public func execute() {
 		syncQueue.async { [weak self] in
 			if let workItem = self?.workItem {
 				workItem.cancel()


### PR DESCRIPTION
Allows encapsulation of debounce logic in lazy loaded properties and feed into legacy Objective-C API's like `NotificationCenter`, see `#selector(refreshProgress.execute)`:

```
class ViewController: UIViewController {
	
    lazy var refreshProgress: DebouncedLimiter = {
        return DebouncedLimiter(limit: 3) { [weak self] in
            self?.debouncedExecutionCount += 1
        }
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        NotificationCenter.default.addObserver(refreshProgress,
            selector: #selector(refreshProgress.execute),
            name: .UIApplicationDidBecomeActive,
            object: nil
        )
    }
}
```